### PR TITLE
Add logout error handling and remove TODO

### DIFF
--- a/app/Http/Controllers/Web/Identity/LogoutController.php
+++ b/app/Http/Controllers/Web/Identity/LogoutController.php
@@ -18,12 +18,16 @@ readonly class LogoutController
 
     /**
      * Log the user out
-     * @throws Exception
      */
     public function __invoke(): RedirectResponse
     {
-        // todo: テスト
-        ($this->logoutAction)();
+        try {
+            ($this->logoutAction)();
+        } catch (Exception $e) {
+            session()->flash('error', 'Failed to log out. Please try again.');
+
+            return redirect()->back();
+        }
 
         return $this->presenter->buildLogoutResponse();
     }


### PR DESCRIPTION
## Summary
- handle logout errors with flash message and redirect
- remove leftover TODO and throws annotation

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bafc9a58e4832c9c5ba8852520d67b